### PR TITLE
Do not inject css links in banner and footer

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -106,16 +106,19 @@ function injectThemeCssLinks(theme) {
 
   return {
     name: 'inject-theme-css-links',
-    transformIndexHtml(html) {
-      const links = files.map(file => ({
-        tag: 'link',
-        attrs: {
-          rel: 'stylesheet',
-          href: `${baseUrl}/${file}`,
-          'data-theme': theme
-        },
-        injectTo: 'head'
-      }));
+    transformIndexHtml(html, ctx) {
+      const doTransform = html.includes('<head>') || ctx.path.endsWith('head.html');
+      const links = doTransform
+        ? files.map(file => ({
+            tag: 'link',
+            attrs: {
+              rel: 'stylesheet',
+              href: `${baseUrl}/${file}`,
+              'data-theme': theme
+            },
+            injectTo: 'head'
+          }))
+        : [];
       return { html, tags: links };
     }
   };


### PR DESCRIPTION
It appears that the `injectTo: 'head'` setting will inject code at the beginning of a file if the file does not contain a \<head\> tag. Meaning that css links will be injected into _all_ files, including banner.html and footer.html. This PR adds a check so that css links are only injected into files having a \<head\> tag or being the head.html file.